### PR TITLE
Only forward anonymous requests to results if anonymous access to results is allowed

### DIFF
--- a/content/views.py
+++ b/content/views.py
@@ -12,7 +12,7 @@ def main(request):
     loginUser(request)
 
     if not request.user.is_authenticated:
-        if raceBlockFinished(config.finalPrefix):
+        if raceBlockFinished(config.finalPrefix) and config.activateResults:
             return redirect('/results')
         else:
             return redirect('/timetable')


### PR DESCRIPTION
If the final race is conducted, a request to the main site without any sub-site given in the URL is redirected to the results page instead of the timetable page. This fails and ends up in an endless loop, if anonymous access to the results page is forbidden.

This is because the results page will redirect back to the main site without authorization (and then to whatever site is set there as the defualt, which happens to bem the result page in that particular case).